### PR TITLE
fix: filter out UNLICENSED dependencies

### DIFF
--- a/src/models/License.ts
+++ b/src/models/License.ts
@@ -1,5 +1,10 @@
 export default class License {
-  static noticeNotRequiredLicenses = ['0BSD', 'Public Domain', 'Unlicense']
+  static noticeNotRequiredLicenses = [
+    '0BSD',
+    'Public Domain',
+    'Unlicense',
+    'UNLICENSED'
+  ]
 
   constructor(
     readonly libraryName: string,


### PR DESCRIPTION
Fix for issue #39
Just add UNLICENSED license to the discarded licence list