### PR TITLE
【bug fix】exclude direct devDependencies when do not need

### DIFF
--- a/src/reader/PackageReader.ts
+++ b/src/reader/PackageReader.ts
@@ -23,7 +23,6 @@ export default function readPackages(cmdOpt: CmdOption): Promise<License[]> {
         if (err) {
           reject(err)
         }
-        console.log(directDependencies)
         const licenseList = walkDependencies(
           pkg,
           new LicenseList({}, cmdOpt),


### PR DESCRIPTION
https://github.com/k-tomoyasu/react-native-oss-license/issues/44  

fix the following bug.

There are cases that direct depend `devDependencies` are included in output even through not use `--dev` option.  
It is happen when your application `devDependencies` include "library A" and your `dependencies` library's `dependencies` include "library A".  