### PR TITLE
new option bundle_id

### DIFF
--- a/src/cmd/LicenseCommand.ts
+++ b/src/cmd/LicenseCommand.ts
@@ -23,6 +23,11 @@ export default class LicenseCommand {
         'skip licenses those not require copyright notice',
         false
       )
+      .option(
+        '--bundle-id <bundleId>',
+        'unique id of your app.  It is used for output such as "plist" filename, etc.',
+        null
+      )
       .version('0.0.1', '--version', 'show current version')
   }
 
@@ -40,7 +45,8 @@ export default class LicenseCommand {
       outputPath: command.outputPath,
       addVersionNumber: command.addVersionNumber,
       onlyDirectDependency: command.onlyDirectDependency,
-      skipNotRequired: command.skipNotRequired
+      skipNotRequired: command.skipNotRequired,
+      bundleId: command.bundleId
     }
   }
 }

--- a/src/formatter/ios/SettingsBundle.ts
+++ b/src/formatter/ios/SettingsBundle.ts
@@ -1,8 +1,6 @@
 import Formatter from '../Formatter'
 import License from '../../models/License'
 
-const baseName = 'com.k-tomoyasu.react-native-oss-license'
-
 export default class SettingBundlesFormatter implements Formatter {
   constructor(
     private opt: SettingsBundleOption,
@@ -11,9 +9,12 @@ export default class SettingBundlesFormatter implements Formatter {
   ) {}
 
   output(licenses: License[]): void {
+    const baseName =
+      this.opt.bundleId || 'com.k-tomoyasu.react-native-oss-license'
     const basePath = this.opt.outputPath || `ios/${baseName}.Output`
     const licenseListContent = this.detailFormatter.outputDetail(
       licenses,
+      baseName,
       basePath
     )
     const plist = `<?xml version="1.0" encoding="UTF-8"?>
@@ -42,7 +43,11 @@ export default class SettingBundlesFormatter implements Formatter {
 
 export class SettingBundlesDetailFormatter {
   constructor(private writer: Writer, private opt: SettingsBundleOption) {}
-  outputDetail(licenses: License[], basePath: string): string {
+  outputDetail(
+    licenses: License[],
+    baseName: string,
+    basePath: string
+  ): string {
     let licenseListContent = ''
     licenses.forEach(license => {
       const libraryName = this.opt.addVersionNumber

--- a/src/models/CmdOption.ts
+++ b/src/models/CmdOption.ts
@@ -7,4 +7,5 @@ type CmdOption = {
   readonly addVersionNumber: boolean
   readonly onlyDirectDependency: boolean
   readonly skipNotRequired: boolean
+  readonly bundleId: string | null
 }

--- a/src/models/FormatterOption.ts
+++ b/src/models/FormatterOption.ts
@@ -3,6 +3,8 @@ type FormatterOption = {
   readonly addVersionNumber: boolean
 }
 
-type SettingsBundleOption = {} & FormatterOption
+type SettingsBundleOption = {
+  readonly bundleId: string | null
+} & FormatterOption
 type AboutLibrariesOption = {} & FormatterOption
 type LicenseToolsPluginOption = {} & FormatterOption


### PR DESCRIPTION
close https://github.com/k-tomoyasu/react-native-oss-license/issues/47  

Add new option `bundle-id`(your app unique  name) that is used for output such as "plist" filename, etc.