### PR TITLE
Support newer AboutLibraries version (over v10.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,64 @@
 # react-native-oss-license
+
 [![npm badge](https://badge.fury.io/js/react-native-oss-license.svg)](https://www.npmjs.com/package/react-native-oss-license)  
 `react-native-oss-license` is **license list generator for React Native App(iOS & Android)**.  
 It generates license lists of npm libraries for iOS, Android.  
 This CLI tool allow you to easily generate content of oss-license.
 
 ## Installation
+
 `npm i -g react-native-oss-license`
 
-## [Sample App](https://github.com/k-tomoyasu/react-native-oss-license/tree/master/sample/) 
+## [Sample App](https://github.com/k-tomoyasu/react-native-oss-license/tree/master/sample/)
 
 ## Usage
+
 ### iOS
-Recommended to use with [LicensePlist](https://github.com/mono0926/LicensePlist) that scan cocoaopds, carthage.  
+
+Recommended to use with [LicensePlist](https://github.com/mono0926/LicensePlist) that scan cocoaopds, carthage.
 
 #### [LicensePlist](https://github.com/mono0926/LicensePlist)
+
 `react-native-oss-license` generate `plist` that you can locate to `Settings.bundle`.  
 Run `react-native-oss-license --format settings-bundle` when your are in the directory that contains `package.json`
 You can merge output `react-native-oss-license` and `LicensePlist`.
 
 ### Android
+
 It is assumed to be used with other tools.
 
 #### LicenseToolsPlugin
+
 [License Tools Plugin for Android](https://github.com/cookpad/LicenseToolsPlugin) is Gradle plugin to check library licenses and generate license pages.  
 Run `react-native-oss-license --format license-tools-plugin`.
 It generate license list in YAML format.  
 `react-native-oss-license` generate same format content. You can merge results.
 
-#### AboutLibraries
+#### AboutLibraries(under v8.9.4)
+
 [AboutLibraries](https://github.com/mikepenz/AboutLibraries) provides fragment/activity that show license list.  
 `react-native-oss-license` generate string resource xml `AboutLibraries` use.  
 Run `react-native-oss-license --format about-libraries`, output strings.xml that you can put into `res/values/`.  
 and output stdout `withLibraries("package_name_A", "package_name_B" ...)` that pass to method `withLibraries`.
 
+#### AboutLibraries(over v10.0.0)
+
+[AboutLibraries](https://github.com/mikepenz/AboutLibraries) provides Jetpack Compose that show license list.  
+`react-native-oss-license` generate JSON files `AboutLibraries` use.  
+Run `react-native-oss-license --format about-libraries-json`, output .json that you can put into `config`.  
+`config/libraries` contains libraries json files.
+`config/licenses` contains licenses json files.
+You can specify any other directory instead of `config` with `--output-path` option.
+
 ### CLI
+
 ```sh
 > cd {project-root}
 > react-native-oss-license --help
 Usage: react-native-oss-license [options]
 
 Options:
-  -f, --format <format>       output format. options:[settings-bundle,license-tools-plugin,about-libraries]
+  -f, --format <format>       output format. options:[settings-bundle,license-tools-plugin,about-libraries, about-libraries-json]
   --dev                       include devDependencies (default: false)
   --depth <depth>             dependencies depth (default: null)
   --output-path <outputPath>  specify path where output file
@@ -58,17 +76,23 @@ output settings-bundle format to 'ios/com.k-tomoyasu.react-native-oss-license.Ou
 ```
 
 ## screen-shots
+
 ### iOS
+
 ![settings-bundle-list](screenshots/settings-bundle-list.png)
 ![settings-bundle-detail](screenshots/settings-bundle-detail.png)
 
 ### Android
+
 #### license-tools-plugin
+
 ![license-tools-plugin](screenshots/license-tools-plugin.png)
 
 #### AboutLibraries
+
 ![about-libraries](screenshots/about-libraries.png)
 
 ## Acknowledgment
+
 This is based on [dart-oss-licenses](https://github.com/ko2ic/dart_oss_licenses) consepts.  
 And referred [license-list](https://github.com/yami-beta/license-list).

--- a/src/formatter/FormatterFactory.ts
+++ b/src/formatter/FormatterFactory.ts
@@ -6,6 +6,7 @@ import LicenseToolsPlugin from './android/LicenseToolsPlugin'
 import Format from '../models/Format'
 import AboutLibraries from './android/AboutLibraries'
 import FileWriter from '../writer/FileWriter'
+import AboutLibrariesJson from './android/AboutLibrariesJson'
 
 export default class FormatterFactory {
   static create(opt: CmdOption): Formatter {
@@ -21,6 +22,8 @@ export default class FormatterFactory {
         return new LicenseToolsPlugin(opt, writer)
       case Format.AboutLibraries:
         return new AboutLibraries(opt, writer)
+      case Format.AboutLibrariesJson:
+        return new AboutLibrariesJson(opt, writer)
       default: {
         throw new Error(
           `invalid format [${

--- a/src/formatter/android/AboutLibrariesJson.ts
+++ b/src/formatter/android/AboutLibrariesJson.ts
@@ -24,7 +24,12 @@ export default class AboutLibrariesJson implements Formatter {
 
       const libraryJson = {
         uniqueId: libraryUniqueId,
-        developers: [authorName],
+        developers: [
+          {
+            name: authorName,
+            organisationUrl: ''
+          }
+        ],
         artifactVersion: version,
         description,
         name,

--- a/src/formatter/android/AboutLibrariesJson.ts
+++ b/src/formatter/android/AboutLibrariesJson.ts
@@ -1,0 +1,83 @@
+import he from 'he'
+
+import Formatter from '../Formatter'
+import License from '../../models/License'
+
+export default class AboutLibrariesJson implements Formatter {
+  constructor(private opt: AboutLibrariesJsonOption, private writer: Writer) {}
+
+  output(licenses: License[]): void {
+    const configPath = this.opt.outputPath || 'android/config'
+    const licensesPath = `${configPath}/licenses`
+    const librariesPath = `${configPath}/libraries`
+
+    const licenseIdentifiers: string[] = []
+    licenses.forEach(license => {
+      const authorName = license.authorName
+      const name = license.libraryName
+      const version = license.version
+      const description = he.encode(license.description)
+      const licenseName = license.license ? license.license : ''
+      const libraryUniqueId = this.getLibraryUniqueId(license)
+      const licenseUniqueId = this.getLicenseUniqueId(license)
+
+      const libraryJson = {
+        uniqueId: libraryUniqueId,
+        developers: [authorName],
+        artifactVersion: version,
+        description,
+        name,
+        tag: '',
+        licenses: [licenseUniqueId]
+      }
+
+      const libraryJsonPath = `${librariesPath}/${libraryUniqueId}.json`
+      this.writer
+        .write(libraryJsonPath, JSON.stringify(libraryJson))
+        .then(() =>
+          console.log(`output about-libraries format to '${libraryJsonPath}'.`)
+        )
+        .catch(e => console.error(e))
+
+      if (
+        licenseUniqueId != '' &&
+        !licenseIdentifiers.includes(licenseUniqueId)
+      ) {
+        licenseIdentifiers.push(licenseUniqueId)
+        const content = license.licenseContent
+        const licenseJson = {
+          content,
+          hash: licenseUniqueId,
+          url: '',
+          name: licenseName
+        }
+
+        const licenseJsonPath = `${licensesPath}/${licenseUniqueId}.json`
+        this.writer
+          .write(licenseJsonPath, JSON.stringify(licenseJson))
+          .then(() =>
+            console.log(
+              `output about-libraries format to '${licenseJsonPath}'.`
+            )
+          )
+          .catch(e => console.error(e))
+      }
+    })
+  }
+
+  private getLibraryUniqueId(license: License): string {
+    return license.libraryName.replace(' ', '_').replace('/', '_')
+  }
+
+  private getLicenseUniqueId(license: License): string {
+    if (license.license == null) {
+      return ''
+    }
+    const prefix = license.license.replace(' ', '_')
+    if (license.licenseContent == '') {
+      return prefix
+    } else {
+      return `${prefix}_${this.getLibraryUniqueId(license)}`
+    }
+  }
+}

--- a/src/formatter/android/AboutLibrariesJson.ts
+++ b/src/formatter/android/AboutLibrariesJson.ts
@@ -1,4 +1,5 @@
 import he from 'he'
+import crypto from 'crypto'
 
 import Formatter from '../Formatter'
 import License from '../../models/License'
@@ -77,7 +78,12 @@ export default class AboutLibrariesJson implements Formatter {
     if (license.licenseContent == '') {
       return prefix
     } else {
-      return `${prefix}_${this.getLibraryUniqueId(license)}`
+      const licenseContentHash = crypto
+        .createHash('sha256')
+        .update(Buffer.from(license.licenseContent))
+        .digest('hex')
+      // same license and licenseContent is considered identical
+      return `${prefix}_${licenseContentHash}`
     }
   }
 }

--- a/src/models/Format.ts
+++ b/src/models/Format.ts
@@ -2,7 +2,8 @@
 enum Format {
   SettingsBunddle = 'settings-bundle',
   LicenseToolsPlugin = 'license-tools-plugin',
-  AboutLibraries = 'about-libraries'
+  AboutLibraries = 'about-libraries',
+  AboutLibrariesJson = 'about-libraries-json'
 }
 
 namespace Format {

--- a/src/models/FormatterOption.ts
+++ b/src/models/FormatterOption.ts
@@ -12,4 +12,5 @@ type AboutLibrariesOption = {
    */
   usesPlugin: boolean
 } & FormatterOption
+type AboutLibrariesJsonOption = {} & FormatterOption
 type LicenseToolsPluginOption = {} & FormatterOption


### PR DESCRIPTION
Newer AboutLibraries version(over v10.0.0) supports [configuration path for additional licenses or libraries](https://github.com/mikepenz/AboutLibraries#gradle-plugin-configuration).
This changes support this new configuration.

## Example
```sh
# output path becomes `config` if --output-path is not specified
$ react-native-oss -f about-libraries-json --output-path custom_dir
output about-libraries format to 'custom_dir/licenses/MIT_117da2af0d4ce0fe1c8e19b5cff9dcd806adf973d328d27b11d4448c4ff24f76.json'.
...
output about-libraries format to 'custom_dir/libraries/once.json'.
$ cat custom_dir/licenses/MIT_117da2af0d4ce0fe1c8e19b5cff9dcd806adf973d328d27b11d4448c4ff24f76.json | jq                                                                                                                                     
{
  "content": "MIT License\n\nCopyright (c) 2014-present Sebastian McKenzie and other contributors\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\nNONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\nLIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\nWITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n",
  "hash": "MIT_117da2af0d4ce0fe1c8e19b5cff9dcd806adf973d328d27b11d4448c4ff24f76",
  "url": "",
  "name": "MIT"
}
$ cat custom_dir/libraries/once.json | jq                                                                                                                                                                                                    
{
  "uniqueId": "once",
  "developers": [
    {
      "name": "Isaac Z. Schlueter",
      "organisationUrl": ""
    }
  ],
  "artifactVersion": "1.4.0",
  "description": "Run a function exactly one time",
  "name": "once",
  "tag": "",
  "licenses": [
    "ISC_4ec3d4c66cd87f5c8d8ad911b10f99bf27cb00cdfcff82621956e379186b016b"
  ]
}
```

## Output

Output `libraries` and `licenses` json files to match AboutLibraries requirements.

`custom_dir/libraries` contains `{lib_name}.json` files.
`custom_dir/licenses` contains `{license_name}_{license_content_hash}.json` files.
license_content_hash aims to distinct same licenses that license text is different.